### PR TITLE
Fix dokku support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+export BUILDPACK_URL=https://github.com/azolotko/heroku-buildpack-rust


### PR DESCRIPTION
Same as with my [buildpack pull request](https://github.com/azolotko/heroku-buildpack-rust/pull/1). I needed to add just one file to link the builpdack and now it works with dokku as well.